### PR TITLE
Fix: add azuread_service_principal_passwords to local.remote.tf

### DIFF
--- a/caf_solution/local.remote.tf
+++ b/caf_solution/local.remote.tf
@@ -14,6 +14,9 @@ locals {
         )
       }
     )
+    azuread_service_principal_passwords = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azuread_service_principal_passwords, {}))
+    }
     azuread_service_principals = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azuread_service_principals, {}))
     }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The code in terraform-azurerm-caf/locals.combined_objects.tf tries to read azuread_service_principal_passwords from var.remote_objects, but azuread_service_principal_passwords was never added to the code in caf-terraform-landingzones/caf_solution/local.remote.tf. This PR adds the missing code.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
